### PR TITLE
Allow usage of "php://input"

### DIFF
--- a/php-malware-finder/php.yar
+++ b/php-malware-finder/php.yar
@@ -312,7 +312,14 @@ rule DodgyStrings
         $ = "meterpreter" fullword
         $ = "nc -l" fullword
         $ = "netstat -an" fullword
-        $ = "php://"
+        $ = "php://stdin"
+        $ = "php://stdout"
+        $ = "php://stderr"
+        $ = "php://output"
+        $ = "php://fd"
+        $ = "php://memory"
+        $ = "php://temp"
+        $ = "php://filter"
         $ = "ps -aux" fullword
         $ = "rootkit" fullword nocase
         $ = "slowloris" fullword nocase


### PR DESCRIPTION
### Description
The `DodgyStrings` rule restricts reading input stream with `file_get_contents('php://input')` by disallowing `php://` prefixed strings.

To allow reading input stream, `php://` prefix is replaced with exact forbidden stream definitions in `DodgyStrings` rule. All PHP streams except `php://input` are restricted.

### Test instructions
1. Ensure you have followed [the installation steps](https://github.com/Automattic/php-malware-finder#installation) and have Yara installed.
2. Check out this branch.
3. Run the check against file containing `php://input` string in code: `php-malware-finder/php-malware-finder/yara.php PATH_TO_TESTED_FILE`
4. Confirm no error for presence of `php://input` string is returned.