### PR TITLE
Remove hacker dodgy string rule

### DIFF
--- a/php-malware-finder/php.yar
+++ b/php-malware-finder/php.yar
@@ -333,7 +333,6 @@ rule DodgyStrings
         $ = /(r[e3]v[e3]rs[e3]|w[3e]b|cmd)\s*sh[e3]ll/ nocase
         $ = /-perm -0[24]000/ // find setuid files
         $ = /\/bin\/(ba)?sh/ fullword
-        $ = /hack(ing|er|ed)/ nocase
         $ = /(safe_mode|open_basedir) bypass/ nocase
         $ = /xp_(execresultset|regenumkeys|cmdshell|filelist)/
 


### PR DESCRIPTION
## Description

The DodgyString rule that checks for words like `hacker`, `hacking`, and `hacked` are causing issues with tests that would include harmless content like a _Hackernews_ icon or a comment _// This is a hack_.

This rule doesn't seem to provide any direct values but returns false positives, so I would like to remove it.

## Testing instructions

1. Ensure you have followed [the installation steps](https://github.com/Automattic/php-malware-finder#installation) and have Yara installed.
2. Check out this branch.
3. Run the check against file containing `hacker` string in code: `php-malware-finder/php-malware-finder/yara.php PATH_TO_TESTED_FILE`
4. Confirm no error for presence of `hacker` string is returned.
