### PR TITLE
Add phpseclib to whitelist

### DIFF
--- a/php-malware-finder/php.yar
+++ b/php-malware-finder/php.yar
@@ -202,7 +202,7 @@ private rule IRC
         5 of them
 }
 
-private rule base64
+private rule b64
 {
     strings:
         $user_agent = "SFRUUF9VU0VSX0FHRU5UCg"
@@ -264,7 +264,7 @@ private rule strrev
 rule SuspiciousEncoding
 {
     condition:
-        (base64 or hex or strrev or Hpack) and not IsWhitelisted
+        (b64 or hex or strrev or Hpack) and not IsWhitelisted
 }
 
 rule DodgyStrings

--- a/php-malware-finder/php.yar
+++ b/php-malware-finder/php.yar
@@ -155,7 +155,7 @@ rule DangerousPhp
         $ = "suhosin.executor.func.blacklist" nocase
         $ = "unregister_tick_function" fullword nocase
         $ = "win32_create_service" fullword nocase
-        $ = "xmlrpc_decode" fullword nocase nocase
+        $ = "xmlrpc_decode" fullword nocase
         $ = /ob_start\s*\(\s*[^\)]/  //ob_start('assert'); echo $_REQUEST['pass']; ob_end_flush();
 
         $whitelist = /escapeshellcmd|escapeshellarg/ nocase

--- a/php-malware-finder/whitelist.yar
+++ b/php-malware-finder/whitelist.yar
@@ -12,6 +12,7 @@ include "whitelists/magento1ce.yar"
 include "whitelists/magento2.yar"
 include "whitelists/prestashop.yar"
 include "whitelists/custom.yar"
+include "whitelists/phpseclib.yar"
 
 
 private rule Magento : ECommerce

--- a/php-malware-finder/whitelist.yar
+++ b/php-malware-finder/whitelist.yar
@@ -126,5 +126,7 @@ private rule IsWhitelisted
         Dotclear or
         Owncloud or
         Phpmyadmin or
-        Misc
+        Misc or
+        PhpSecLib or
+        false
 }

--- a/php-malware-finder/whitelists/phpseclib.yar
+++ b/php-malware-finder/whitelists/phpseclib.yar
@@ -1,0 +1,73 @@
+/*
+phpseclib (https://phpseclib.com/, https://github.com/phpseclib/phpseclib) is a widely-used and well-established
+PHP library implementing a variety of cryptographic functions (hashes, key exchanges, encryption algorithms etc.)
+For performance reasons, its implementation makes use of direct memory streams like php://memory, which violates
+the DodgyStrings rule. However, phpseclib is to be considered safe (so long as it's not used for nefarious
+purposes, e.g. cryptolockers), so we whitelist it here.
+
+When a new version of phpseclib is released, you generate hashes for newly-violating files with something like:
+yara -r ./php.yar /path/to/phpseclib-NEWVERSION | sed -e 's/.* //' | xargs sha1sum
+*/
+
+private rule PhpSecLib
+{
+	condition:
+		/* phpseclib 3.0.16 */
+		hash.sha1(0, filesize) == "8e21c685e20f93652251f0d3558e7ee5246baeb4" or // Net/SFTP.php
+		hash.sha1(0, filesize) == "e74689576bff65f9f9e915207a7a533147909527" or // Net/SSH2.php
+		hash.sha1(0, filesize) == "3e5ecc6fcccd77de8fab836d026c46d8a45c0392" or // Crypt/RSA/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "728b0fcfb1c56d3ced695b3842881a339aa7525a" or // Crypt/EC/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "a33643c70a4d4fabc1691692602bc0979ca2481f" or // File/ASN1.php
+		hash.sha1(0, filesize) == "bbcecc586fa2017b9f42e7b232b4891173862be2" or // Crypt/Common/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "582a5384b56f951e77b0f84321073f77afcaadbe" or // System/SSH/Agent.php
+		hash.sha1(0, filesize) == "b0eec5ecc264c39ce3a5696207f64590efe1dac3" or // Crypt/DSA/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "e3b7fb5f166bec43bbd0b42879682f0b30dda2c3" or // Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
+
+		/* phpseclib 3.0.15 */
+		hash.sha1(0, filesize) == "05aea088182d157d444c6b36edda7e6df9e6ee21" or // Net/SSH2.php
+
+		/* phpseclib 3.0.14 */
+		hash.sha1(0, filesize) == "678a602cf49377b881b3e66e9e7852c6c8e6393c" or // Net/SSH2.php
+		hash.sha1(0, filesize) == "678a602cf49377b881b3e66e9e7852c6c8e6393c" or // Net/SSH2.php
+		hash.sha1(0, filesize) == "6f1ab9a433937d82f8a754e618547052dcacf093" or // Net/SFTP.php
+		hash.sha1(0, filesize) == "c1474a59cfe3d4b55ff073e41f2a7829716a64cb" or // Crypt/RSA/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "b409197545a7b0c5d113849d24bd92e60b4c8769" or // Crypt/EC/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "e250dddcd0af3901512232e235a17cbc4a424937" or // File/ASN1.php
+		hash.sha1(0, filesize) == "3e12a95466f9bb46ce14a0cd18605967b403cf46" or // Crypt/DSA/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "cc67782fb7df240c17e2edd5b89429b13bb1974c" or // Crypt/Common/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "4bb24c0cdef6168bc9b96d74b68de8b44ac6286b" or // System/SSH/Agent.php
+		hash.sha1(0, filesize) == "ff834692a1f87059043ef664b0ee95e13893f0a4" or // Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
+
+		/* phpseclib 3.0.13 */
+		hash.sha1(0, filesize) == "eaa2dc1c4c82f6471ad02f94f6482dacf9a1f9a8" or // Net/SFTP.php
+		hash.sha1(0, filesize) == "af9deaa665280ebf5332d16c0bf7caf288966191" or // Net/SSH2.php
+		hash.sha1(0, filesize) == "d80ac076a2f25a8600c9afb98c40cded47cdbc4d" or // Crypt/RSA/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "ad6dbd5170818020da3d6a6a182e2808966b378e" or // Crypt/EC/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "d4cbc20b7786b61e10102382dd4792034f1fe974" or // File/ASN1.php
+		hash.sha1(0, filesize) == "f9ad77e450fd8551de63149a5a9aed8c9f0e1a69" or // Crypt/DSA/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "5cda44c290308b16cb20bd486467bd811446d92e" or // Crypt/Common/Formats/Keys/OpenSSH.php
+		hash.sha1(0, filesize) == "35f65c2dd2d9a3ea07f90e3caa22948339d62532" or // System/SSH/Agent.php
+		hash.sha1(0, filesize) == "902aaf064e5231b000f0b93358489f578ecba6aa" or // Math/BigInteger/Engines/PHP/Reductions/EvalBarrett.php
+
+		/* phpseclib 2.0.38 */
+		hash.sha1(0, filesize) == "89cdbe2e338f8808fcb04cd2190614ad35515673" or // Net/SFTP/Stream.php
+		hash.sha1(0, filesize) == "a35b9ffd69ed48af4d8a5d15f6f7adf61f903549" or // Crypt/Hash.php
+		hash.sha1(0, filesize) == "036c6bdec1f9edb7e733aea194a9ce89980e7c9c" or // Net/SSH1.php
+		hash.sha1(0, filesize) == "5fa63055657d779f2fc8516ab188d1508d072804" or // Net/SFTP.php
+		hash.sha1(0, filesize) == "5cf735268949db17b2e601fa62effc24d53b3ce7" or // Crypt/RSA.php
+		hash.sha1(0, filesize) == "cc999a67117745a2a174789e98d422b3bb5cb59c" or // System/SSH/Agent.php
+		hash.sha1(0, filesize) == "c81a407e592add708d6a48d094287d15aab2072b" or // Net/SSH2.php
+		hash.sha1(0, filesize) == "c81a407e592add708d6a48d094287d15aab2072b" or // Net/SSH2.php
+
+		/* phpseclib 2.0.37 */
+		hash.sha1(0, filesize) == "56020444fd4b836cfb638b6635b32a8e9d713cc1" or // Net/SFTP.php
+		hash.sha1(0, filesize) == "1314d15c88989220a1432eba308a5749a380e91a" or // Crypt/RSA.php
+		hash.sha1(0, filesize) == "9760729cd424843ab97921d0b780f3d86215ef01" or // Net/SSH2.php
+		hash.sha1(0, filesize) == "a1e9eaae8a5404242c08737d344953d3d6da023f" or // Math/BigInteger.php
+
+		/* phpseclib 2.0.36 */
+		hash.sha1(0, filesize) == "882f2b562f01590e1301654ba174def5496c4163" or // Crypt/RSA.php
+		hash.sha1(0, filesize) == "f072de508131bc230f628bbb600bdd3443af4667" or // System/SSH/Agent.php
+
+		false
+}


### PR DESCRIPTION
## Description

phpseclib ([www](https://phpseclib.com/), [github](https://github.com/phpseclib/phpseclib)) is a popular, safe, battle-tested PHP library providing a variety of cryptographic utility functions for e.g. hash generation and comparison, key exchange, encryption and decryption etc.

It is highly preferable for developers to use a library like phpseclib rather than implementing crypto themselves (the ["don't roll your own crypto" principle](https://www.schneier.com/blog/archives/2015/05/amateurs_produc.html)). However, embedding phpseclib currently fails a variety of DodgyString and ObfuscatedPHP rules, principally because phpseclib uses `php://memory` and similar constructs to optimise performance.

We should whitelist phpseclib to allow it to be used. We already whitelist some parts of it where we expect those parts to be included in trusted packages (e.g. Magento CMS); let's just trust the whole thing!

## Changes

- Added a phpseclib whitelist [61f845c6a388ca198ddde47a52944af96e3a997f]
- Changed the way that external whitelists are linked in [95b05f401c1187348ac2dd7fd5f29c59384624c8] to use the `or\nfalse` pattern, which makes adding additional items/commenting out items temporarily easier (similar to adding a trailing comma to arrays)
- Removed a duplicate `nocase` statement which was throwing warnings [542b5c6d941e98f92cae613b4812ddbd1cf33d4a] (this was done upstream [here](https://github.com/jvoisin/php-malware-finder/commit/2eaca5164f8ba9ad43ddb645a547d393508d0590))
- Renamed the `base64` rule to `b64` to support yara 4.x+ (this was done upstream [here](https://github.com/jvoisin/php-malware-finder/commit/08214fc5242df1616355c8bdb16ab367be970f42))

## Testing

1. Set up php-malware-scanner in accordance with [the README](https://github.com/Automattic/php-malware-finder/blob/master/README.md). E.g. on a Mac, you might need to run `brew install yara`; note that if you install yara 4.x+ you won't be able to run `master` because yara 4.x adds `base64` as a keyword.
2. Download and extract [a recent release of phpseclib](https://github.com/phpseclib/phpseclib/releases).
3. Run php-malware-scanner against the version of phpseclib you downloaded and see that it passes the whitelist, e.g. you might run `yara -r php-malware-finder/php.yar ~/phpseclib-3.0.16` if you downloaded phpseclib 3.0.16. The expected output is only a warning about a DodgyPhp rule using an inefficient regular expression.
4. (Optional) Switch to `master` (or [comment out this line temporarily](https://github.com/Automattic/php-malware-finder/blob/12c7735f68bcb0e535e96db94beef4082b133dd1/php-malware-finder/whitelist.yar#L130)) and run it again to see how we _used_ to detect phpseclib as malware.
5. (Optional) Create a `.php` file containing an invalid string like `php://memory` and see how that _still_ fails the test if you run the malware finder against it, even though we allow this string when used inside phpseclib.

## Further considerations

We're likely to have to update this whitelist periodically. I've added instructions to the top of the file to help future developers do this, but if this becomes painful then really smart move might be to automate it (for the most-recent versions of phpseclib) by having the malware scanner download (if necessary) recent versions of phpseclib, generate hashes, and whitelist them itself?