### PR TITLE
Add guzzle and tcpdf to whitelist

### DIFF
--- a/php-malware-finder/whitelist.yar
+++ b/php-malware-finder/whitelist.yar
@@ -13,6 +13,8 @@ include "whitelists/magento2.yar"
 include "whitelists/prestashop.yar"
 include "whitelists/custom.yar"
 include "whitelists/phpseclib.yar"
+include "whitelists/guzzle.yar"
+include "whitelists/tcpdf.yar"
 
 
 private rule Magento : ECommerce
@@ -128,5 +130,7 @@ private rule IsWhitelisted
         Phpmyadmin or
         Misc or
         PhpSecLib or
+        Guzzle or
+        TCPDF or
         false
 }

--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -1,0 +1,64 @@
+/*
+Guzzle (https://github.com/guzzle/guzzle) is a popular PHP library providing a HTTP client implementation.
+It makes use of php://temp and unusually-named variables (e.g. $nano), but is harmless and we'd rather
+developers use Guzzle than roll-their-own (assuming that wp_ HTTP methods are unsuitable for them), so we
+whitelist Guzzle.
+
+When a new version of Guzzle is released, you generate hashes for newly-violating files with something like:
+yara -r ./php.yar /path/to/guzzle-NEWVERSION | sed -e 's/.* //' | xargs sha1sum | uniq
+*/
+
+private rule Guzzle
+{
+	condition:
+		/* Guzzle 6.5.8 */
+		hash.sha1(0, filesize) == "22826b712b77c50d85a96a3876e212682056d707" or // Handler/MockHandler.php
+		hash.sha1(0, filesize) == "eb5669521a15c4c376fc54b7e90561699bbf7aa5" or // functions.php
+		hash.sha1(0, filesize) == "dd228b9beb40785b42daabfc6c13e425eb127893" or // HandlerStack.php
+		hash.sha1(0, filesize) == "2c1385b58fb14b73c389fa44fed7a8368cd7be32" or // Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "a568713580e06682dbf99dcbadeb2442bad5663c" or // Handler/CurlFactory.php
+
+		/* Guzzle 7.0.0 */
+		hash.sha1(0, filesize) == "f669c0c479fb0a7c20a3d862ac262b8ae87442ac" or // Handler/MockHandler.php
+		hash.sha1(0, filesize) == "983eb255307afde2115057f99dd2e3d6030f9fec" or // HandlerStack.php
+		hash.sha1(0, filesize) == "07bf28a699d50dec06513e53e13d91f68e44f7b7" or // Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "7b9daacde2e3713e60d89c5d29fa7e3fd9bcd351" or // Utils.php
+		hash.sha1(0, filesize) == "c6b6019202934665058c0cdcacf23874a8eff0ed" or // Handler/CurlFactory.php
+
+		/* Guzzle 7.1.0 */
+		hash.sha1(0, filesize) == "d9770bcfcfc99b67f6e7673199f1814b7e285cb5" or // Handler/MockHandler.php
+		hash.sha1(0, filesize) == "9b59fd58bb1fe9dc3427f30e82eeaacdb0943b69" or // Utils.php
+		hash.sha1(0, filesize) == "5a8aa96d137ab0e9c20094472eb1bc1da4d73556" or // HandlerStack.php
+		hash.sha1(0, filesize) == "5eeb1e6930ae01b11a9eccdcb942629adb2d9ee6" or // Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "f65e96a98ba8f7d5ae6c701adc5f1318b2a536f7" or // Handler/StreamHandler.php
+
+		/* Guzzle 7.1.1 */
+		hash.sha1(0, filesize) == "8e1c5078d5ad9515593f089deda402885a79444c" or // Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "ac33174b9f058f724b8eb5f891b213d0b31a9ae4" or // Handler/MockHandler.php
+		hash.sha1(0, filesize) == "d3337a10adf0132cc07002d1f9bcdce35b1fef2a" or // Handler/StreamHandler.php
+
+		/* Guzzle 7.2.0 */
+		hash.sha1(0, filesize) == "278cb92f31edf6df92616d2db346dea4f37896dc" or // Handler/MockHandler.php
+		hash.sha1(0, filesize) == "fca03c8181f84629e2b3f574f0fa6f27ae131ba8" or // Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "4d298db54ac0c551025d828e522ada86108c8e41" or // Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "f0b9cafd50ea74a23db19d0f1ef353cba949660c" or // Utils.php
+
+		/* Guzzle 7.3.0 */
+		hash.sha1(0, filesize) == "01137ae48d5ecd32aab3580554034123f9bff634" or // Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "9bae979882f7a12fe4029f60b3ef32a60b7de0b1" or // Utils.php
+		hash.sha1(0, filesize) == "657caf9a0ec92030ee3abbca128fe7a2b892189b" or // Handler/StreamHandler.php
+
+		/* Guzzle 7.4.0 */
+		hash.sha1(0, filesize) == "1a1ab72b3aa4bf341e8241d2d61156711c542700" or // Utils.php
+		hash.sha1(0, filesize) == "eef71556af334dc04505d7db99be86449d3c9eec" or // Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "67be3724995423ee61d41299d1c8eab6ac153fc9" or // Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "a2ea7adf581db39f309e72750d6cec5a321281a3" or // HandlerStack.php
+
+		/* Guzzle 7.4.2 */
+		hash.sha1(0, filesize) == "fb22fb7d7d9364ebbc3bcbc614998c9da8274c94" or // "Handler/StreamHandler.php
+
+		/* Guzzle 7.5.0 */
+		hash.sha1(0, filesize) == "f296c95e0bda52295667b0eba42084fb6c3c4f86" or // Utils.php
+
+		false
+}

--- a/php-malware-finder/whitelists/tcpdf.yar
+++ b/php-malware-finder/whitelists/tcpdf.yar
@@ -1,0 +1,29 @@
+/*
+TCPDF (https://github.com/tecnickcom/TCPDF, https://tcpdf.org/) provides PHP-based PDF generation. It seems
+to be a widely-used and trustworthy piece of open-source software. We incorrectly tag it as containing
+"ObfuscatedPhp" because it contains barcode header/metadata in relatively compressed formats, like
+\xE2\x80\x93 or long lists of chr(...) calls.
+
+When a new version of TCPDF is released, you generate hashes for newly-violating files with something like:
+yara -r ./php.yar /path/to/tcpdf-NEWVERSION | sed -e 's/.* //' | xargs sha1sum | uniq
+
+You'll probably find that only the file tcpdf_barcodes_1d.php routinely changes, and not with every release.
+*/
+
+private rule TCPDF
+{
+	condition:
+		/* TCPDF 6.3.5 */
+		hash.sha1(0, filesize) == "914fb29209a5da691fcb759af241e66098cc190f" or // tcpdf_barcodes_1d.php
+
+		/* TCPDF 6.4.0 - 6.4.1 */
+		hash.sha1(0, filesize) == "52aa12ea4f8c4b76745f4e23438302b57bb77c70" or // tcpdf_barcodes_1d.php
+
+		/* TCPDF 6.4.2 - 6.4.3 */
+		hash.sha1(0, filesize) == "c76cea52506beed08793222634122892cd1a6767" or // tcpdf_barcodes_1d.php
+
+		/* TCPDF 6.4.4 - 6.6.1 */
+		hash.sha1(0, filesize) == "23c7eac806621bfb7f3f2138b9753ddc387c3bf4" or // tcpdf_barcodes_1d.php
+
+		false
+}


### PR DESCRIPTION
## Description

Guzzle ([gh](https://github.com/guzzle/guzzle)) is a popular PHP library providing a HTTP client implementation. It makes use of php://temp and unusually-named variables (e.g. $nano), but is harmless and we'd rather developers use Guzzle than roll-their-own (assuming that wp_ HTTP methods are unsuitable for them). We've already whitelisted previous Guzzle versions where they've been dependencies of other tools we've whitelisted.

TCPDF ([gh](https://github.com/tecnickcom/TCPDF), [www](https://tcpdf.org/)) provides PHP-based PDF generation. It seems to be a widely-used and trustworthy piece of open-source software. We incorrectly tag it as containing "ObfuscatedPhp" because it contains barcode header/metadata in relatively compressed formats, like `\xE2\x80\x93` or long lists of `chr(...)` calls.

Discovered during deployment by a 3PD; see [this Slack thread](https://a8c.slack.com/archives/C4E0DVDB2/p1670950179747509).

## Changes

- Added recent versions of Guzzle and TCPDF to whitelist

## Testing

1. Set up php-malware-scanner in accordance with [the README](https://github.com/Automattic/php-malware-finder/blob/master/README.md). E.g. on a Mac, you might need to run `brew install yara`; note that if you install yara 4.x+ you won't be able to run `master` because yara 4.x adds `base64` as a keyword.
2. Download and extract recent releases of Guzzle and TCPDF (follow gh links above and grab a ZIP file!).
3. Run php-malware-scanner against the versions of Guzzle and TCPDF you downloaded and see that it passes the whitelist, e.g. you might run `yara -r php-malware-finder/php.yar ~/guzzle-7.3.0`. Expect to see only warnings.
4. (Optional) Switch to `master` and run it again to see how we _used_ to detect Guzzle and TCPDF as malware.
5. (Optional) Create a `.php` file containing an invalid string like `php://temp` and see how that _still_ fails the test if you run the malware finder against it, even though we allow this string when used inside Guzzle.

## Further considerations

See also #3, which was the last time we expanded the whitelists.