### PR TITLE
Fix Guzzle dependencies false positive

### DIFF
--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -6,6 +6,9 @@ whitelist Guzzle.
 
 When a new version of Guzzle is released, you generate hashes for newly-violating files with something like:
 yara -r ./php.yar /path/to/guzzle-NEWVERSION | sed -e 's/.* //' | xargs sha1sum | uniq
+
+BEFORE GENERATING NEW HASHES, be sure to run composer i --no-dev in the guzzle directory, because guzzle
+has sub-dependencies (like psr7) which introduce their own (php://temp) false positives otherwise!
 */
 
 private rule Guzzle

--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -55,6 +55,18 @@ private rule Guzzle
 		hash.sha1(0, filesize) == "2f8f9c5c258ffe6adad71e95c4a831e58e9d39d8" or // vendor/guzzlehttp/psr7/src/CachingStream.php
 		hash.sha1(0, filesize) == "7d026b5256fddb20cbd1d0820f53393585bdd173" or // vendor/guzzlehttp/psr7/src/Utils.php
 
+		/* Guzzle < 7.4.0 is compatible with several older (but still safe) versions of PSR7, so we whitelist them separately: */
+		/* PSR7 1.7.0: */
+		hash.sha1(0, filesize) == "33c19430ff582dbee1a2ed125b68d05b9916d510" or // src/CachingStream.php
+		hash.sha1(0, filesize) == "392133877d19bd90a76a61a208f13485823d0f34" or // src/Utils.php
+
+		/* PSR7 1.8.0: */
+		hash.sha1(0, filesize) == "5ba04c2124acb1694fd4882eb288af67b6ca3e68" or // src/CachingStream.php
+		hash.sha1(0, filesize) == "a7ad421c7bec23b30cdad0ca6fdfb59bfac205e8" or // src/Utils.php
+
+		/* PSR7 1.8.1 - 1.9.x: */
+		hash.sha1(0, filesize) == "9fc9f16d55e2d1dab08df073224acc825c4e8b13" or // src/Utils.php
+
 		/* Guzzle 7.4.0 */
 		hash.sha1(0, filesize) == "1a1ab72b3aa4bf341e8241d2d61156711c542700" or // Utils.php
 		hash.sha1(0, filesize) == "eef71556af334dc04505d7db99be86449d3c9eec" or // Handler/CurlFactory.php
@@ -66,6 +78,18 @@ private rule Guzzle
 
 		/* Guzzle 7.5.0 */
 		hash.sha1(0, filesize) == "f296c95e0bda52295667b0eba42084fb6c3c4f86" or // Utils.php
+
+		/* Guzzle > 7.5.0 is compatible with PSR7 versions in the 2.x range, so we whitelist them separately: */
+		/* PSR7 2.0.0: */
+		hash.sha1(0, filesize) == "3d5215560b3b52503daaa850e720c316a0740b3c" or // src/CachingStream.php
+		hash.sha1(0, filesize) == "e4188cf754b1cdfe60cbb5ae81742f21aa2bcf56" or // src/Utils.php
+
+		/* PSR7 2.1.0: */
+		hash.sha1(0, filesize) == "2e5b277fb486de73618cf4efcf21a0281137723d" or // src/CachingStream.php
+		hash.sha1(0, filesize) == "3f3675d0be4f3183d123e486123760089d2bb289" or // src/Utils.php
+
+		/* PSR7 2.2.0 - 2.4.3: */
+		hash.sha1(0, filesize) == "f0a3f9ec88e10ed3ec0259a9be0f8cba6ff49a52" or // src/Utils.php
 
 		false
 }

--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -42,11 +42,15 @@ private rule Guzzle
 		hash.sha1(0, filesize) == "fca03c8181f84629e2b3f574f0fa6f27ae131ba8" or // Handler/StreamHandler.php
 		hash.sha1(0, filesize) == "4d298db54ac0c551025d828e522ada86108c8e41" or // Handler/CurlFactory.php
 		hash.sha1(0, filesize) == "f0b9cafd50ea74a23db19d0f1ef353cba949660c" or // Utils.php
+		hash.sha1(0, filesize) == "23e657d45588252d391e9dda48f1bb69e6fd0fc5" or // vendor/guzzlehttp/psr7/src/CachingStream.php
+		hash.sha1(0, filesize) == "62d77fe44861b2f09b099d4573953666d2177b9d" or // vendor/guzzlehttp/psr7/src/Utils.php
 
 		/* Guzzle 7.3.0 */
 		hash.sha1(0, filesize) == "01137ae48d5ecd32aab3580554034123f9bff634" or // Handler/CurlFactory.php
 		hash.sha1(0, filesize) == "9bae979882f7a12fe4029f60b3ef32a60b7de0b1" or // Utils.php
 		hash.sha1(0, filesize) == "657caf9a0ec92030ee3abbca128fe7a2b892189b" or // Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "2f8f9c5c258ffe6adad71e95c4a831e58e9d39d8" or // vendor/guzzlehttp/psr7/src/CachingStream.php
+		hash.sha1(0, filesize) == "7d026b5256fddb20cbd1d0820f53393585bdd173" or // vendor/guzzlehttp/psr7/src/Utils.php
 
 		/* Guzzle 7.4.0 */
 		hash.sha1(0, filesize) == "1a1ab72b3aa4bf341e8241d2d61156711c542700" or // Utils.php


### PR DESCRIPTION
## Description

Following #4, the vendor who identified the problem [still wasn't able to upload](https://a8c.slack.com/archives/C4E0DVDB2/p1671238365490159?thread_ts=1670950179.747509&cid=C4E0DVDB2). This is because `guzzle` has a dependency defined in its `composer.json` (PSR7) that in turn fails the malware checks. When I created the `guzzle` hashes I failed to first run `composer i --no-dev` in the `guzzle` directory to get these sub-dependencies, and so I didn't include them in the new hashes.

This PR adds the missing hashes for Guzzle's preferred versions of PSR7 _and_ for a handful of older/newer versions that are inter-compatible (and so _could_ end up included depending on the extension's other dependencies!); I've also manually checked against the 3PD's extension so I'm more confident that this one actually fixes the reported problem than I was in #4!

## Testing

Test as #4, _but_: when you download a copy of Guzzle, run `composer i --no-dev` in its directory before running Yara against it (with e.g. `yara -r ./php.yar ~/Downloads/guzzle-7.2.0`).

Alternatively, download the offending plugin - [swisspost.zip](https://github.com/Automattic/php-malware-finder/files/10258391/swisspost.zip) - unzip, and run against that, with e.g. `yara -r ./php.yar ~/Downloads/swisspost`.