### PR TITLE
Add Google API Client to whitelist

### DIFF
--- a/php-malware-finder/whitelist.yar
+++ b/php-malware-finder/whitelist.yar
@@ -15,6 +15,7 @@ include "whitelists/custom.yar"
 include "whitelists/phpseclib.yar"
 include "whitelists/guzzle.yar"
 include "whitelists/tcpdf.yar"
+include "whitelists/google-api-php-client.yar"
 
 
 private rule Magento : ECommerce
@@ -132,5 +133,6 @@ private rule IsWhitelisted
         PhpSecLib or
         Guzzle or
         TCPDF or
+        GoogleAPIPHPClient or
         false
 }

--- a/php-malware-finder/whitelists/google-api-php-client.yar
+++ b/php-malware-finder/whitelists/google-api-php-client.yar
@@ -41,5 +41,10 @@ private rule GoogleAPIPHPClient
 		hash.sha1(0, filesize) == "5ce78df7baf162e9509a70808c91b9cc6bf5ca70" or // vendor/phpseclib/phpseclib/phpseclib/System/SSH/Agent.php
 		hash.sha1(0, filesize) == "5cb79490002a0bf985479e6cac67ce38758be730" or // vendor/psr/log/Psr/Log/Test/LoggerInterfaceTest.php
 
+		/* Google API client 2.13.0 */
+		hash.sha1(0, filesize) == "2a64b8300cdf5fa94ca8b5a47d060e8a3e203e82" or // src/Client.php
+		hash.sha1(0, filesize) == "2f8f9c5c258ffe6adad71e95c4a831e58e9d39d8" or // vendor/guzzlehttp/psr7/src/CachingStream.php
+		hash.sha1(0, filesize) == "7d026b5256fddb20cbd1d0820f53393585bdd173" or // vendor/guzzlehttp/psr7/src/Utils.php
+
 		false
 }

--- a/php-malware-finder/whitelists/google-api-php-client.yar
+++ b/php-malware-finder/whitelists/google-api-php-client.yar
@@ -1,0 +1,45 @@
+/*
+The Google API PHP Client (https://github.com/googleapis/google-api-php-client) is Google's official PHP library for accessing
+Google APIs. It's a heavyweight but good way for extensions that use Google APIs (e.g. for OAuth) to implement the functionality
+we need, and it's authoritative (as an official API), well-maintained, and a good candidate for whitelisting.
+
+When a new version is released, you generate hashes for newly-violating files with something like:
+yara -r ./php.yar /path/to/google-api-php-client-NEWVERSION | sed -e 's/.* //' | xargs sha1sum | uniq
+
+Notes:
+
+ - The Google API PHP Client seems to come in different "flavors" by PHP version (5.4 [!], 7.0, 7.4, 8.0) but, for v2.12.6 at
+   least, we've not seen any significant difference in the files that trigger our malware scanner. In future, it may be sufficient
+   to only download and test the PHP 8.0 flavor. The exception is the PHP 7.2 polyfill (from Symfony), which is unlikely to change.
+ - The API embeds phpseclib, which is already whitelisted elsewhere but duplicated here in case our policy on non-embedded phpseclib
+   changes, and Monolog, which is a logging management library whose design makes it suitable for both web and CLI applications
+   (and some of the features it provides to support CLI applications, e.g. use of php://stdout, trip up our malware scanner).
+*/
+
+private rule GoogleAPIPHPClient
+{
+	condition:
+		/* PHP 7.2 Polyfill used by the Google API Client */
+		hash.sha1(0, filesize) == "119ddfca28fade11d0054a8526328cb76df742e3" or // e.g. vendor/symfony/polyfill-php72/Php72.php
+
+		/* Google API client 2.12.6 */
+		hash.sha1(0, filesize) == "397b4a5384a9f9e678fe757ea3c4b7d797b94df3" or // src/Client.php
+		hash.sha1(0, filesize) == "5048b750ebb9b4a2163cf38d8b06139d5fa0f62c" or // vendor/google/apiclient-services/src/CertificateManager/GclbTarget.php
+		hash.sha1(0, filesize) == "1bb88ea5dd0d038d5c25409d976415eac35308b0" or // vendor/google/apiclient-services/src/CertificateManager/IpConfig.php
+		hash.sha1(0, filesize) == "2f14bcae31235ba4e5231be0a5053abfc841e9a1" or // vendor/google/apiclient-services/src/DatabaseMigrationService/CloudSqlSettings.php
+		hash.sha1(0, filesize) == "9c11afa3e888bbe9cfb3e69e279e5d1c2571131c" or // vendor/google/apiclient-services/src/DatabaseMigrationService/CloudSqlSettings.php
+		hash.sha1(0, filesize) == "08786770df112df01f07131539e953babb356609" or // vendor/monolog/monolog/src/Monolog/Handler/FingersCrossed/ChannelLevelActivationStrategy.php
+		hash.sha1(0, filesize) == "b5c842295a491aca621422f17a86f93785d91995" or // vendor/monolog/monolog/src/Monolog/Handler/FingersCrossed/ChannelLevelActivationStrategy.php
+		hash.sha1(0, filesize) == "531c64ee23eafef46240184cae4f178c969c621a" or // vendor/monolog/monolog/src/Monolog/Handler/InsightOpsHandler.php
+		hash.sha1(0, filesize) == "67b7a9729cfb19a762101648b39dbe9d6223d03e" or // vendor/monolog/monolog/src/Monolog/Handler/InsightOpsHandler.php
+		hash.sha1(0, filesize) == "5ea9f3251a4d8772dd59f1777860b8fc34f7babb" or // vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "6d94aa73d61fd786cf8bc8882943ba4c7a5d249a" or // vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "a62707d307fbb303a85838e1e26efb4c318e8f31" or // vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "c82bb8141b1e4fb4ad98eb313b5dd302ab350d21" or // vendor/monolog/monolog/src/Monolog/Logger.php
+		hash.sha1(0, filesize) == "705486556a52a42f84149ac87b550db5ab79e8e3" or // vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php
+		hash.sha1(0, filesize) == "7e0327dc43840b460921b2183fc48a3f1b5477e1" or // vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php
+		hash.sha1(0, filesize) == "5ce78df7baf162e9509a70808c91b9cc6bf5ca70" or // vendor/phpseclib/phpseclib/phpseclib/System/SSH/Agent.php
+		hash.sha1(0, filesize) == "5cb79490002a0bf985479e6cac67ce38758be730" or // vendor/psr/log/Psr/Log/Test/LoggerInterfaceTest.php
+
+		false
+}

--- a/php-malware-finder/whitelists/google-api-php-client.yar
+++ b/php-malware-finder/whitelists/google-api-php-client.yar
@@ -43,8 +43,6 @@ private rule GoogleAPIPHPClient
 
 		/* Google API client 2.13.0 */
 		hash.sha1(0, filesize) == "2a64b8300cdf5fa94ca8b5a47d060e8a3e203e82" or // src/Client.php
-		hash.sha1(0, filesize) == "2f8f9c5c258ffe6adad71e95c4a831e58e9d39d8" or // vendor/guzzlehttp/psr7/src/CachingStream.php
-		hash.sha1(0, filesize) == "7d026b5256fddb20cbd1d0820f53393585bdd173" or // vendor/guzzlehttp/psr7/src/Utils.php
 
 		false
 }


### PR DESCRIPTION
## Description

The [Google API PHP Client](https://github.com/googleapis/google-api-php-client) is Google's official PHP library for accessing Google APIs. It's a bit heavyweight but still a good way for extensions that use Google APIs (e.g. for OAuth) to implement the functionality they need. E.g. [it's used by Social Login Pro, for example](https://a8c.slack.com/archives/C01JHKF3XPC/p1668879999137549).

This library uses `php://temp` as part of its API handshaking, and a logging library it depends on has `php://stderr` etc. calls (because the logging library is designed to be able to work for CLI as well as web applications). These trip the malware scanner, but we should approve use of the Google API Client library, so let's whitelist it.

## Changes

- Add the latest version (v2.12.6) of the Google API PHP Client to the whitelist
- Also add v2.13.0

## Testing

1. Set up php-malware-scanner in accordance with [the README](https://github.com/Automattic/php-malware-finder/blob/master/README.md). E.g. on a Mac, you might need to run `brew install yara`.
2. Download and extract either version of the Google API PHP Client listed above (https://github.com/googleapis/google-api-php-client/releases)
4. Run php-malware-scanner against it with e.g. you might run `yara -r php-malware-finder/php.yar ~/google-api-php-client`. Expect to see only warnings.
5. (Optional) Download and extract a copy of Social Login Pro (from [this Slack thread](https://a8c.slack.com/archives/C01JHKF3XPC/p1669663023302229?thread_ts=1668879999.137549&cid=C01JHKF3XPC)) and run against it in the same way
6. Note: if PR #5 isn't merged yet you may get some failures from GuzzleHTTP/PSR7 files. Run `sha1sum <filename>` against any failing files and confirm that their hashes appear in in that PR ([look here!](https://github.com/Automattic/php-malware-finder/pull/5/files)).