### PR TITLE
Add Google API Clients v2.12.1 through v2.12.5 to whitelist

### DIFF
--- a/php-malware-finder/whitelists/google-api-php-client.yar
+++ b/php-malware-finder/whitelists/google-api-php-client.yar
@@ -22,7 +22,21 @@ private rule GoogleAPIPHPClient
 		/* PHP 7.2 Polyfill used by the Google API Client */
 		hash.sha1(0, filesize) == "119ddfca28fade11d0054a8526328cb76df742e3" or // e.g. vendor/symfony/polyfill-php72/Php72.php
 
-		/* Google API client 2.12.6 */
+		/* Google API client 2.12.1 - 2.12.2 (and some locked dependencies distinct to the 2.12.1 series) */
+		hash.sha1(0, filesize) == "bff5b1e332dd756cd5285e3ea9bbba424618d397" or // src/Client.php
+		hash.sha1(0, filesize) == "0c5db532158835759e7389dfaa8d27fbe799872c" or // vendor/phpseclib/phpseclib/phpseclib/Net/SFTP.php
+		hash.sha1(0, filesize) == "9d3d980c43dd79895802a6ab4bc9e7092f2ed5dc" or // vendor/phpseclib/phpseclib/phpseclib/Net/SSH2.php
+		hash.sha1(0, filesize) == "cc7a3ef86e89b536c70beb446125a2f2998f6888" or // vendor/google/apiclient-services/src/DatabaseMigrationService/CloudSqlSettings.php
+		hash.sha1(0, filesize) == "147422321d204c396fb8b96554d4cef988e86e86" or // vendor/monolog/monolog/src/Monolog/Handler/InsightOpsHandler.php
+		hash.sha1(0, filesize) == "70bfd248729665a098d55ee5f21ffe0a873c919d" or // vendor/monolog/monolog/src/Monolog/Handler/StreamHandler.php
+
+		/* Google API client 2.12.3 - 2.12.4 */
+		hash.sha1(0, filesize) == "caad14d057d1a0dcf48dde2b3c46e153c4818e72" or // src/Client.php
+
+		/* Google API client 2.12.5 */
+		hash.sha1(0, filesize) == "99a8dd64f6107b3f62781c856a72b9f4c158f610" or // src/Client.php
+
+		/* Google API client 2.12.6 (and many locked dependencies distinct to the 2.12.2+ series) */
 		hash.sha1(0, filesize) == "397b4a5384a9f9e678fe757ea3c4b7d797b94df3" or // src/Client.php
 		hash.sha1(0, filesize) == "5048b750ebb9b4a2163cf38d8b06139d5fa0f62c" or // vendor/google/apiclient-services/src/CertificateManager/GclbTarget.php
 		hash.sha1(0, filesize) == "1bb88ea5dd0d038d5c25409d976415eac35308b0" or // vendor/google/apiclient-services/src/CertificateManager/IpConfig.php


### PR DESCRIPTION
## Description

PR #6 added support for Google API Client v2.12.6 and v2.13.0, but [a vendor is still relying on 2.12.1](https://a8c.slack.com/archives/C01JHKF3XPC/p1672389574830619?thread_ts=1668879999.137549&cid=C01JHKF3XPC). There are no security-related bugfixes in the [release notes for the interim versions](https://github.com/googleapis/google-api-php-client/releases), so we can safely add v2.12.1 through v2.12.5 to the whitelist too.

## Changes

- Added Google API Client libraries v2.12.1 through v2.12.5 to the whitelist

## Testing

1. Set up php-malware-scanner in accordance with [the README](https://github.com/Automattic/php-malware-finder/blob/master/README.md). E.g. on a Mac, you might need to run `brew install yara`.
2. Download and extract any version of the Google API PHP Client listed above (https://github.com/googleapis/google-api-php-client/releases)
4. Run php-malware-scanner against it with e.g. you might run `yara -r php-malware-finder/php.yar ~/google-api-php-client`. Expect to see only warnings.
5. (Optional) Download and extract the latest copy of Social Login Pro's ZIP (from [here](https://a8c.slack.com/archives/C01JHKF3XPC/p1672255635144119?thread_ts=1668879999.137549&cid=C01JHKF3XPC)) and run against it in the same way