### PR TITLE
Add FPDF and Freemius to whitelist

### DIFF
--- a/php-malware-finder/whitelist.yar
+++ b/php-malware-finder/whitelist.yar
@@ -16,7 +16,8 @@ include "whitelists/phpseclib.yar"
 include "whitelists/guzzle.yar"
 include "whitelists/tcpdf.yar"
 include "whitelists/google-api-php-client.yar"
-
+include "whitelists/freemius.yar"
+include "whitelists/fpdf.yar"
 
 private rule Magento : ECommerce
 {
@@ -134,5 +135,7 @@ private rule IsWhitelisted
         Guzzle or
         TCPDF or
         GoogleAPIPHPClient or
+        Freemius or
+        FPDF or
         false
 }

--- a/php-malware-finder/whitelists/fpdf.yar
+++ b/php-malware-finder/whitelists/fpdf.yar
@@ -1,0 +1,23 @@
+/*
+FPDF (and its underlying dependency FPDI, by the same developer) is a moderately-popular PDF file
+manipulation library for PHP. See:
+- https://github.com/setasign/fpdf
+- https://github.com/setasign/fpdi
+
+When a new version of Freemius's WordPress SDK is released, you generate hashes for newly-violating files
+with something like:
+yara -r ./php.yar /path/to/FPDF-NEWVERSION | sed -e 's/.* //' | xargs sha1sum | uniq
+*/
+
+private rule FPDF
+{
+	condition:
+		/* FPDF 1.8.5: */
+		hash.sha1(0, filesize) == "9d6f7cf95d1687aa1747ac850fd59dfacd4b92db" or // fpdf.php
+
+		/* FPDI 1.8.5: */
+		hash.sha1(0, filesize) == "87c5edda50f0f9b980ae2d29b6dfb9f5b56a7ce4" or // src/PdfParser/StreamReader.php
+		hash.sha1(0, filesize) == "c39557036c9df7813dfed1d753073f8efb7abe98" or // src/PdfParser/Filter/Flate.php
+
+		false
+}

--- a/php-malware-finder/whitelists/freemius.yar
+++ b/php-malware-finder/whitelists/freemius.yar
@@ -1,0 +1,22 @@
+/*
+Freemius (freemius.com) is a widely-used library for adding subscription/freemium features to WP
+plugins.
+
+When a new version of Freemius's WordPress SDK is released, you generate hashes for newly-violating files
+with something like:
+yara -r ./php.yar /path/to/freemius-wordpress-sdk-NEWVERSION | sed -e 's/.* //' | xargs sha1sum | uniq
+*/
+
+private rule Freemius
+{
+	condition:
+		/* 2.5.4: */
+		hash.sha1(0, filesize) == "c34e59ca2fe2acb1212e6034f0cbd6f4a59d3598" or // templates/add-ons.php
+		hash.sha1(0, filesize) == "f64845f10277c44660b9b0b39b88bc241cf36b82" or // templates/account.php
+		hash.sha1(0, filesize) == "31441221887efc860d49ac5ee77b0f7ccb5476cc" or // includes/class-freemius.php
+
+		/* 2.5.3: */
+		hash.sha1(0, filesize) == "c7443ebbd901ac302e7370886ba2f8e84166c555" or // includes/class-freemius.php
+
+		false
+}


### PR DESCRIPTION
## Description

The Freemius and FPDF/FPDI libraries are widely-used and seem to be safe, so I'd like to add them to the whitelist. This will (partially) unblock [this vendor's submission](https://href.li/?https://a8c.slack.com/archives/C4E0DVDB2/p1677876086791909).

## Testing

To test:
1. Check out this branch (and ensure you've got `yara` installed e.g. using `brew install yara`)
2. Download and extract the latest versions of the offending libraries: [Freemius](https://github.com/Freemius/wordpress-sdk/releases), [FPDI](https://github.com/Setasign/FPDI/releases), [FPDF](https://github.com/Setasign/FPDF/releases)
3. Run `yara -r ./php.yar [PATH TO TEST]` for each path you extracted to and see no obfuscated code or dodgy strings errors.
4. (Optional) Do the same against the extension itself which you can [download from here](https://woocommerce.com/wp-admin/admin.php?page=wc-admin&path=%2Fsubmit-product%2F18734001574587) and extract and see that the only error is _not_ in any of the now-whitelisted libraries
5. (Recommended) [Read/watch my latest learnup](https://alphamattic.wordpress.com/2023/03/07/pbs-whitelisting-libraries-in-the-malware-scanner-learnup/) so you understand what's changed and why you're testing in this way