### PR TITLE
Add comments/docs explaining that TCPDF 6.6.2 works already

### DIFF
--- a/php-malware-finder/whitelist.md
+++ b/php-malware-finder/whitelist.md
@@ -65,7 +65,7 @@ See `whitelist.yar` and the includes in `whitelists/` for instructions on adding
 * 6.4.1
 * 6.4.2
 * 6.4.3
-* 6.4.4 - 6.6.1
+* 6.4.4 - 6.6.2
 
 ## WP-CLI
 

--- a/php-malware-finder/whitelists/tcpdf.yar
+++ b/php-malware-finder/whitelists/tcpdf.yar
@@ -24,7 +24,7 @@ private rule TCPDF
 		/* TCPDF 6.4.2 - 6.4.3 */
 		hash.sha1(0, filesize) == "c76cea52506beed08793222634122892cd1a6767" or // tcpdf_barcodes_1d.php
 
-		/* TCPDF 6.4.4 - 6.6.1 */
+		/* TCPDF 6.4.4 - 6.6.2 */
 		hash.sha1(0, filesize) == "23c7eac806621bfb7f3f2138b9753ddc387c3bf4" or // tcpdf_barcodes_1d.php
 
 		false


### PR DESCRIPTION
## Description

[A vendor upgraded to TCPDF 6.6.2](https://a8c.slack.com/archives/C4E0DVDB2/p1682962203756369?thread_ts=1679942499.835839&cid=C4E0DVDB2). This should already work. This PR only updates comments/documentation to clarify this and show that we tested it.

## Testing

Only comments/documentation are changed, but you should replicate my test to see for yourself that TCPF 6.6.2 works. Here's how:

1. [Download TCPDF 6.6.2](https://github.com/tecnickcom/TCPDF/tags) and decompress it.
2. Check out this branch.
3. Ensure you have `yara` installed (`brew install yara` will probably do it).
4. Run `yara -r ./php.yar ~/Downloads/tcpdf-6.6.2` (assuming you extracted TCPDF 6.6.2 into your Downloads folder; adapt if not)
5. You'll see the usual warning about our DodgyPhp rule (this is because we have a regular expression with an indefinite end; we can't work around this), but no other output (because TCPDF 6.6.2 is fine, per the TCPDF 6.4.4 - 6.6.2 rule).

Given that this isn't a code change, I'm happy with one review on this. If you're the first reviewer, and you're happy with this too, feel free to untag the second reviewer.