### PR TITLE
Add extant Guzzle versions 7.4.3-7.4.5, 7.5.1-7.7.0 to whitelist

### DIFF
--- a/php-malware-finder/whitelist.md
+++ b/php-malware-finder/whitelist.md
@@ -45,7 +45,16 @@ See `whitelist.yar` and the includes in `whitelists/` for instructions on adding
 * 7.3.0
 * 7.4.0
 * 7.4.2
+* 7.4.3
+* 7.4.4
+* 7.4.5
 * 7.5.0
+* 7.5.1
+* 7.5.2
+* 7.5.3
+* 7.6.0
+* 7.6.1
+* 7.7.0
 * Additionally, its dependency PSR7 versions 1.7.0, 1.8.0, 1.8.1, 1.9.x, 2.0.0, 2.1.0, 2.2.0 - 2.4.3
 
 ## [phpseclib](https://github.com/phpseclib/phpseclib)

--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -57,6 +57,27 @@ private rule Guzzle
 		hash.sha1(0, filesize) == "2f8f9c5c258ffe6adad71e95c4a831e58e9d39d8" or // vendor/guzzlehttp/psr7/src/CachingStream.php
 		hash.sha1(0, filesize) == "7d026b5256fddb20cbd1d0820f53393585bdd173" or // vendor/guzzlehttp/psr7/src/Utils.php
 
+		/* Guzzle 7.4.0 */
+		hash.sha1(0, filesize) == "8fa95f46c22e77b7f638cdcc0de2d2e43727ca2f" or // vendor/guzzlehttp/psr7/src/Utils.php
+
+		/* Guzzle 7.5.1 */
+		hash.sha1(0, filesize) == "c1820ad96327fc4bc73b52f92bbcbd824fda87a0" or // Handler/CurlFactory.php
+
+		/* Guzzle 7.5.2 */
+		hash.sha1(0, filesize) == "4dda1d37bfbe7fd6386a6bc7b9f22982a1c277fb" or // Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "5ef08935b2a6b0bb77181275b565ffcce15f9bdc" or // Handler/StreamHandler.php
+
+		/* Guzzle 7.6.0 */
+		hash.sha1(0, filesize) == "9e2a92abdd1c7ec1577dceb5e891e11191ee93bd" or // Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "335f9d8666a5163751edae8b339d820a7141683f" or // Handler/StreamHandler.php
+
+		/* Guzzle 7.7.0 */
+		hash.sha1(0, filesize) == "669e3b48569c116ae013068501fa36cafa16be68" or // /Handler/MockHandler.php
+		hash.sha1(0, filesize) == "3117da236100e5f02608d1ca7d3603938f55b844" or // /Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "a2ee7010131f5ed0c05b9540249a134cd26ca11b" or // /HandlerStack.php
+		hash.sha1(0, filesize) == "8d8e4929e4797dd6b167372d7dcec708fc7e82f7" or // /Utils.php
+		hash.sha1(0, filesize) == "714f54d183c4066c968fd530ae30b018e31b63c6" or // /Handler/StreamHandler.php
+
 		/* Guzzle < 7.4.0 is compatible with several older (but still safe) versions of PSR7, so we whitelist them separately: */
 		/* PSR7 1.7.0: */
 		hash.sha1(0, filesize) == "33c19430ff582dbee1a2ed125b68d05b9916d510" or // src/CachingStream.php


### PR DESCRIPTION
## Description

@jdevieux reported [a vendor's difficulty](https://a8c.slack.com/archives/C4E0DVDB2/p1691511594468669) with the malware scanner blocking newer versions of Guzzle. This PR whitelists those versions.

## Testing

You will need Yara. Install with e.g. `brew install yara`.

1. Check out this branch
2. Download any (or all - you choose!) [releases of Guzzle](https://github.com/guzzle/guzzle/releases) newly-added to [the whitelist](https://github.com/Automattic/php-malware-finder/compare/master...Automattic:php-malware-finder:add/guzzle-through-v7.7.0-to-whitelist?expand=1#diff-1a2bbbdf2033109d0ef683672fc40f110b7244549b607b024e84a3b028330351) (`php-malware-finder/whitelist.md`), decompress them, and run `composer i --no-dev` in each of their directories to install their dependencies.
3. In the `php-malware-finder` folder, run `yara -r ./php.yar /path/to/guzzle-NEWVERSION` (replace the path with the path to the copy of Guzzle you want to test, or optionally a parent directory containing multiple Guzzle versions!)
4. You should expect to see the `warning:` about the `DodgyPhp` rule which uses an unbounded regular expression, as usual. But you shouldn't see any `DodgyStrings` or `ObfuscatedPhp` notifications (switch to the `master` branch to compare, if you like).