### PR TITLE
Relax path traversal detection

### DIFF
--- a/php-malware-finder/php.yar
+++ b/php-malware-finder/php.yar
@@ -278,7 +278,7 @@ rule DodgyStrings
         $ = ".mysql_history"
         $ = ".ssh/authorized_keys"
         $ = "/(.*)/e"  // preg_replace code execution
-        $ = "/../../../"
+        $ = "/../../../../../"
         $ = "/etc/passwd"
         $ = "/etc/proftpd.conf"
         $ = "/etc/resolv.conf"


### PR DESCRIPTION
## Description

We have [a DodgyStrings check](https://github.com/jvoisin/php-malware-finder/blame/master/data/php.yar#L286) that attempts to stop path traversal attacks by searching for `/../../../`. This results in a false positive for [this submission](https://woocommerce.com/wp-admin/admin.php?page=wc-admin&path=%2Fsubmit-product%2F18734002477177).

Given that we're exclusively using this tool to scan WordPress plugins and themes, which necessitates a 5-level structure before a plugin could "break out" into the OS (and try to e.g. exfiltrate `/etc/shadow` or similar), _and_ given that genuine malware would probably try harder than this to disguise path traversal attacks, _and_ given that modern operating systems (assuming properly-configured hosting, e.g. not running PHP as root!) are better at partitioning filesystem access anyway, I see no problem with relaxing this rule to `/../../../../../`. This prevents this false positive without significantly weakening the protections afforded by the check.

## Testing

### Happy Path

If you want to replicate my test that this stops the false positive:

1. Check out the `master` branch. Ensure you have `yara` installed (e.g. `brew install yara`). Get into the `php-malware-finder/php-malware-finder` directory.
2. Download and extract the problematic extension (`swifterm`).
3. Run e.g. `yara -sr ./php.yar ~/Downloads/swifterm` to scan the extension and see the false positives.
4. Switch to this branch.
5. Run that command again and see no false positives (just the warning about unbounded regular expressions).

### Sad Path

If you want to try to come up with some believable malware that passes the new check but not the old, be my guest. 😆 