### PR TITLE
Update Guzzle/PSR7 whitelist

### DIFF
--- a/php-malware-finder/whitelist.md
+++ b/php-malware-finder/whitelist.md
@@ -55,7 +55,9 @@ See `whitelist.yar` and the includes in `whitelists/` for instructions on adding
 * 7.6.0
 * 7.6.1
 * 7.7.0
-* Additionally, its dependency PSR7 versions 1.7.0, 1.8.0, 1.8.1, 1.9.x, 2.0.0, 2.1.0, 2.2.0 - 2.4.3
+* 7.7.1
+* 7.8.0
+* Additionally, its dependency PSR7 versions 1.7.0, 1.8.0, 1.8.1, 1.9.x, 2.0.0, 2.1.0, 2.2.0 - 2.6.0, 2.6.1
 
 ## [phpseclib](https://github.com/phpseclib/phpseclib)
 

--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -102,6 +102,13 @@ private rule Guzzle
 		/* Guzzle 7.5.0 */
 		hash.sha1(0, filesize) == "f296c95e0bda52295667b0eba42084fb6c3c4f86" or // Utils.php
 
+		/* Guzzle 7.7.1 */
+		hash.sha1(0, filesize) == "bc011ec58482c307f42528146a02b2a97829bf43" or // HandlerStack.php
+		hash.sha1(0, filesize) == "079c74b3aceb2d4503718a16eb3033645078d68e" or // Handler/CurlFactory.php
+
+		/* Guzzle 7.8.0 */
+		hash.sha1(0, filesize) == "4a638381a4069206f93d07700011c34d2785aee2" or // Handler/CurlFactory.php
+
 		/* Guzzle > 7.5.0 is compatible with PSR7 versions in the 2.x range, so we whitelist them separately: */
 		/* PSR7 2.0.0: */
 		hash.sha1(0, filesize) == "3d5215560b3b52503daaa850e720c316a0740b3c" or // src/CachingStream.php
@@ -111,8 +118,11 @@ private rule Guzzle
 		hash.sha1(0, filesize) == "2e5b277fb486de73618cf4efcf21a0281137723d" or // src/CachingStream.php
 		hash.sha1(0, filesize) == "3f3675d0be4f3183d123e486123760089d2bb289" or // src/Utils.php
 
-		/* PSR7 2.2.0 - 2.4.3: */
+		/* PSR7 2.2.0 - 2.6.0: */
 		hash.sha1(0, filesize) == "f0a3f9ec88e10ed3ec0259a9be0f8cba6ff49a52" or // src/Utils.php
+
+		/* PSR7 2.6.1: */
+		hash.sha1(0, filesize) == "b3ab1ccd21afd624505c629da42137a1863fee56" or // src/Utils.php
 
 		false
 }

--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -89,7 +89,7 @@ private rule Guzzle
 		hash.sha1(0, filesize) == "5ba04c2124acb1694fd4882eb288af67b6ca3e68" or // src/CachingStream.php
 		hash.sha1(0, filesize) == "a7ad421c7bec23b30cdad0ca6fdfb59bfac205e8" or // src/Utils.php
 
-		/* PSR7 1.8.1 - 1.9.x: */
+		/* PSR7 1.8.1 - 1.9.1: */
 		hash.sha1(0, filesize) == "9fc9f16d55e2d1dab08df073224acc825c4e8b13" or // src/Utils.php
 
 		/* Guzzle 7.4.0 */

--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -10,6 +10,8 @@ yara -r ./php.yar /path/to/guzzle-NEWVERSION | sed -e 's/.* //' | xargs sha1sum 
 BEFORE GENERATING NEW HASHES, be sure to run composer i --no-dev in the guzzle directory, because guzzle
 has sub-dependencies (like psr7) which introduce their own (php://temp) false positives otherwise!
 
+If PSR7 has "jumped" a few version in the meantime you might like to download the intermediary versions too.
+
 When adding/updating lists, be sure to update ../whitelist.md too!
 */
 

--- a/php-malware-finder/whitelists/guzzle.yar
+++ b/php-malware-finder/whitelists/guzzle.yar
@@ -99,7 +99,7 @@ private rule Guzzle
 		hash.sha1(0, filesize) == "a2ea7adf581db39f309e72750d6cec5a321281a3" or // HandlerStack.php
 
 		/* Guzzle 7.4.2 */
-		hash.sha1(0, filesize) == "fb22fb7d7d9364ebbc3bcbc614998c9da8274c94" or // "Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "fb22fb7d7d9364ebbc3bcbc614998c9da8274c94" or // Handler/StreamHandler.php
 
 		/* Guzzle 7.5.0 */
 		hash.sha1(0, filesize) == "f296c95e0bda52295667b0eba42084fb6c3c4f86" or // Utils.php


### PR DESCRIPTION
Fixes #13.

## Test instructions

1. Have `yara` installed (e.g. `brew install yara`)
2. Check out this branch.
3. Download and decompress any (or each) new version of [GuzzleHTTP](https://github.com/guzzle/guzzle/releases/) (7.7.1 or 7.8.0)
4. In the GuzzleHTTP directory, run `composer i --no-dev` to install its dependencies (will include the latest version of PSR7)
5. (Optional) Manually download and decompress any (or each) new version of [PSR7](https://github.com/guzzle/psr7/releases/) (1.9.1 and/or 2.4.5+)
6. In the `php-malware-finder` subdirectory, run the malware scanner against each thing you downloaded with e.g. `yara -r ./php.yar /path/to/thing/you/downloaded`
7. You should only see the message `warning: rule "DodgyPhp" in ./php.yar(93): $pr contains .*, .+ or .{x,} consider using .{,N}, .{1,N} or {x,N} with a reasonable value for N` and not any `DodgyStrings` or `ObfuscatedPhp` errors.

## Understand

Note that this won't actually fix the issue reported as it relates to a different problem ([it turns out the offending code has been tampered with, probably by an autolinter](https://a8c.slack.com/archives/C4E0DVDB2/p1693842246420759?thread_ts=1692979004.536579&cid=C4E0DVDB2)). However, it's still worth us updating our whitelist of this popular and safe dependency.