### PR TITLE
Added whitelist for certain files used by Vendor 23642

### DIFF
--- a/php-malware-finder/whitelist.md
+++ b/php-malware-finder/whitelist.md
@@ -1,9 +1,11 @@
 # Whitelisted libraries
 
+## Generic libraries
+
 The following libraries are whitelisted and won't be detected as malware by the scanner.
 See `whitelist.yar` and the includes in `whitelists/` for instructions on adding/updating this list.
 
-## [Carbon](https://github.com/briannesbitt/Carbon)
+### [Carbon](https://github.com/briannesbitt/Carbon)
 
 * 2.55.x
 * 2.56.x - 2.58.x
@@ -11,20 +13,20 @@ See `whitelist.yar` and the includes in `whitelists/` for instructions on adding
 * 2.61.0 - 2.64.1
 * 2.65.0 - 2.66.0
 
-## [FPDF](https://github.com/setasign/fpdf)
+### [FPDF](https://github.com/setasign/fpdf)
 
 * 1.8.5
 
-## [FPDI](https://github.com/setasign/fpdi)
+### [FPDI](https://github.com/setasign/fpdi)
 
 * 2.3.7
 
-## [Freemius](https://freemius.com/)' [WordPress SDK](https://github.com/freemius/wordpress-sdk)
+### [Freemius](https://freemius.com/)' [WordPress SDK](https://github.com/freemius/wordpress-sdk)
 
 * 2.5.3
 * 2.5.4
 
-## [Google API PHP Client](https://github.com/googleapis/google-api-php-client)
+### [Google API PHP Client](https://github.com/googleapis/google-api-php-client)
 
 * 2.12.1
 * 2.12.2
@@ -35,7 +37,7 @@ See `whitelist.yar` and the includes in `whitelists/` for instructions on adding
 * 2.13.0
 * Additionally, the `vendor/symfony/polyfill-php72` polyfill used by the Google API PHP Client
 
-## [Guzzle](https://github.com/guzzle/guzzle)
+### [Guzzle](https://github.com/guzzle/guzzle)
 
 * 6.5.8
 * 7.0.0
@@ -59,7 +61,7 @@ See `whitelist.yar` and the includes in `whitelists/` for instructions on adding
 * 7.8.0
 * Additionally, its dependency PSR7 versions 1.7.0, 1.8.0, 1.8.1, 1.9.x, 2.0.0, 2.1.0, 2.2.0 - 2.6.0, 2.6.1
 
-## [phpseclib](https://github.com/phpseclib/phpseclib)
+### [phpseclib](https://github.com/phpseclib/phpseclib)
 
 * 3.0.16
 * 3.0.15
@@ -69,7 +71,7 @@ See `whitelist.yar` and the includes in `whitelists/` for instructions on adding
 * 2.0.37
 * 2.0.36
 
-## [TCPDF](https://github.com/tecnickcom/TCPDF)
+### [TCPDF](https://github.com/tecnickcom/TCPDF)
 
 * 6.3.5
 * 6.4.0
@@ -78,9 +80,23 @@ See `whitelist.yar` and the includes in `whitelists/` for instructions on adding
 * 6.4.3
 * 6.4.4 - 6.6.2
 
-## WP-CLI
+### WP-CLI
 
 * 2.5.0
 * 2.6.0
 * 2.7.x
 * 2.8.0-alpha
+
+## Namespaced libraries used by specific vendors
+
+Some vendors include namespaced versions of libraries to avoid conflicts with other WordPress plugins. Till we get a better solution, we are whitelisting files them individually.
+
+### Vendor 23642
+
+#### [Guzzle](https://github.com/guzzle/guzzle)
+
+* 6.5.5
+
+#### [Symfony Polyfill](https://github.com/symfony/polyfill)
+
+* 1.28 (?)

--- a/php-malware-finder/whitelist.yar
+++ b/php-malware-finder/whitelist.yar
@@ -14,6 +14,7 @@ include "whitelists/guzzle.yar"
 include "whitelists/phpseclib.yar"
 include "whitelists/tcpdf.yar"
 include "whitelists/wp-cli.yar"
+include "whitelists/vendors/23642.yar"
 
 private rule IsWhitelisted
 {
@@ -26,6 +27,7 @@ private rule IsWhitelisted
         PhpSecLib or
         TCPDF or
         WPCLI or
+        Vendor23642 or
 
         false
 }

--- a/php-malware-finder/whitelists/vendors/23642.yar
+++ b/php-malware-finder/whitelists/vendors/23642.yar
@@ -1,0 +1,19 @@
+private rule Vendor23642
+{
+	condition:
+		/* guzzlehttp */
+		hash.sha1(0, filesize) == "565eccf9f43d106028216cddfcba51af675d99cd" or // CachingStream.php
+		hash.sha1(0, filesize) == "b67dcc19adbb175adc875e8d72844f5bce320bca" or // Utils.php
+		hash.sha1(0, filesize) == "e0c7310361b48a3ac0672b3f886d792894a983cd" or // functions.php
+		hash.sha1(0, filesize) == "cc532dc913988f33f350f6f793d4eeee7f35c48a" or // Handler/CurlFactory.php
+		hash.sha1(0, filesize) == "bc4269b4eef575ba2edf83c592ee89eb98800811" or // Handler/MockHandler.php
+		hash.sha1(0, filesize) == "b3afbb3033b51a8f86584355d8ad609f28542b28" or // Handler/StreamHandler.php
+		hash.sha1(0, filesize) == "d348ca3ccc7854dda900c17a4636f7a78335edde" or // HandlerStack.php
+
+		/* symfony */
+		hash.sha1(0, filesize) == "c8d2def34386fdd356cf7616322bb3321b217474" or // Php72.php
+		hash.sha1(0, filesize) == "75f3c050c27a433c925e844e5ba7441ec285d33c" or // disallowed_STD3_mapped.php
+		hash.sha1(0, filesize) == "dd1c293deeb3bdc2283514c619bb020ac443fe73" or // compatibilityDecomposition.php
+
+		false
+}


### PR DESCRIPTION
See p1696599901602139-slack-C046BT55X0E.

This vendor uses Guzzle and Symfony, but they have namespaced these packages to avoid conflicts. So we have to add their particular files to the whitelist.

## Test instructions

1. Have `yara` installed (e.g. `brew install yara`)
2. Check out this branch.
3. Download and unzip the vendor's plugin file. (Ask me for one.)
4. In the `php-malware-finder` subdirectory, run the malware scanner against the folder: `yara -r ./php.yar /path/to/thing/you/downloaded`.
7. You should only see the message `warning: rule "DodgyPhp" in ./php.yar(93): $pr contains .*, .+ or .{x,} consider using .{,N}, .{1,N} or {x,N} with a reasonable value for N` and not any `DodgyStrings` or `ObfuscatedPhp` errors.