### PR TITLE
Added whitelist for file used by Vendor 2274

### DIFF
--- a/php-malware-finder/whitelist.md
+++ b/php-malware-finder/whitelist.md
@@ -100,3 +100,9 @@ Some vendors include namespaced versions of libraries to avoid conflicts with ot
 #### [Symfony Polyfill](https://github.com/symfony/polyfill)
 
 * 1.28 (?)
+
+### Vendor 23642
+
+#### receipt.iife.js
+
+This JS file mistakenly gets identified as containing dodgy PHP code, so we whitelist it.

--- a/php-malware-finder/whitelist.yar
+++ b/php-malware-finder/whitelist.yar
@@ -15,6 +15,7 @@ include "whitelists/phpseclib.yar"
 include "whitelists/tcpdf.yar"
 include "whitelists/wp-cli.yar"
 include "whitelists/vendors/23642.yar"
+include "whitelists/vendors/2274.yar"
 
 private rule IsWhitelisted
 {
@@ -28,6 +29,7 @@ private rule IsWhitelisted
         TCPDF or
         WPCLI or
         Vendor23642 or
+        Vendor2274 or
 
         false
 }

--- a/php-malware-finder/whitelists/vendors/2274.yar
+++ b/php-malware-finder/whitelists/vendors/2274.yar
@@ -1,0 +1,8 @@
+private rule Vendor2274
+{
+	condition:
+		/* receipt.iife.js */
+		hash.sha1(0, filesize) == "dc2ed47e2c191492a218f244aa37b6e5ad713f00" or
+
+		false
+}

--- a/php-malware-finder/whitelists/vendors/2274.yar
+++ b/php-malware-finder/whitelists/vendors/2274.yar
@@ -2,7 +2,7 @@ private rule Vendor2274
 {
 	condition:
 		/* receipt.iife.js */
-		hash.sha1(0, filesize) == "dc2ed47e2c191492a218f244aa37b6e5ad713f00" or
+		hash.sha1(0, filesize) == "d1579b88d167f6e7d92e62ac5fd9e5ccf3fdd4c8" or
 
 		false
 }


### PR DESCRIPTION
See p1704995366616629-slack-C01JHKF3XPC.

This vendor includes a JS file which triggers a malware check only intended for use against PHP files.

## Test instructions

1. Have `yara` installed (e.g. `brew install yara`)
2. [Download the affected JS file](https://files.slack.com/files-pri/T024FN1V2-F06EBCZ6UNL/download/receipte.iife.max.js?origin_team=T024FN1V2)
3. In the `php-malware-finder` subdirectory, run `yara -sr ./php.yar /path/to/the/file.js`; observe failures beginning with `$nano: $1...`
4. Switch to this branch
5. Run the test again and see that the failures have disappeared

Ignore the message `warning: rule "DodgyPhp" in ./php.yar(93): $pr contains .*, .+ or .{x,} consider using .{,N}, .{1,N} or {x,N} with a reasonable value for N` and not any `DodgyStrings` or `ObfuscatedPhp` errors.