### PR TITLE
Update SHA in whitelist for file used by Vendor 2274

### DIFF
--- a/php-malware-finder/whitelist.md
+++ b/php-malware-finder/whitelist.md
@@ -101,7 +101,7 @@ Some vendors include namespaced versions of libraries to avoid conflicts with ot
 
 * 1.28 (?)
 
-### Vendor 23642
+### Vendor 2274
 
 #### receipt.iife.js
 

--- a/php-malware-finder/whitelists/vendors/2274.yar
+++ b/php-malware-finder/whitelists/vendors/2274.yar
@@ -2,7 +2,7 @@ private rule Vendor2274
 {
 	condition:
 		/* receipt.iife.js */
-		hash.sha1(0, filesize) == "d1579b88d167f6e7d92e62ac5fd9e5ccf3fdd4c8" or
+		hash.sha1(0, filesize) == "e0492e6316941a3340bf3139e791aa5c1eaa8ae9" or
 
 		false
 }


### PR DESCRIPTION
In https://github.com/Automattic/php-malware-finder/pull/16, we seem to have used the wrong SHA, because this upload is still failing the scan. I generated this new SHA with

```
yara -r ./php.yar ~/Downloads/[ plugin ]/lib/receipt/dist/receipt.iife.js | sed -e 's/.* //' | xargs shasum | uniq
```

## Test instructions

1. Have `yara` installed (e.g. `brew install yara`)
2. Download the affected JS file.
3. In the `php-malware-finder` subdirectory, run `yara -sr ./php.yar /path/to/the/file.js`; observe failures beginning with `$nano: $1...`
4. Switch to this branch
5. Run the test again and see that the failures have disappeared

Ignore the message `warning: rule "DodgyPhp" in ./php.yar(93): $pr contains .*, .+ or .{x,} consider using .{,N}, .{1,N} or {x,N} with a reasonable value for N` and not any `DodgyStrings` or `ObfuscatedPhp` errors.