### PR TITLE
Add whitelist for certain files for Vendor 3664

### DIFF
--- a/php-malware-finder/whitelist.md
+++ b/php-malware-finder/whitelist.md
@@ -106,3 +106,7 @@ Some vendors include namespaced versions of libraries to avoid conflicts with ot
 #### receipt.iife.js
 
 This JS file mistakenly gets identified as containing dodgy PHP code, so we whitelist it.
+
+### Vendor 3664
+
+Two font files get mistakenly flagged for ObfuscatedPhp and DodgyPhp, so we whitelist them.

--- a/php-malware-finder/whitelist.yar
+++ b/php-malware-finder/whitelist.yar
@@ -16,6 +16,7 @@ include "whitelists/tcpdf.yar"
 include "whitelists/wp-cli.yar"
 include "whitelists/vendors/23642.yar"
 include "whitelists/vendors/2274.yar"
+include "whitelists/vendors/3664.yar"
 
 private rule IsWhitelisted
 {
@@ -30,6 +31,7 @@ private rule IsWhitelisted
         WPCLI or
         Vendor23642 or
         Vendor2274 or
+        Vendor3664 or
 
         false
 }

--- a/php-malware-finder/whitelists/vendors/3664.yar
+++ b/php-malware-finder/whitelists/vendors/3664.yar
@@ -1,0 +1,11 @@
+private rule Vendor3664
+{
+	condition:
+		/* NotoSerif-Italic-VariableFont_wdth_wght.ttf */
+		hash.sha1(0, filesize) == "68c6eb82085932a8c5381772d5323bc735deb6d8" or
+
+		/* NotoSerif-VariableFont_wdth_wght */
+		hash.sha1(0, filesize) == "7e73a5116d127fa32d9f2bea5025a07f92921f75" or
+
+		false
+}


### PR DESCRIPTION
See p1713456758641829/1713440844.588469-slack-C4E0DVDB2.

This vendor uses two font files that get erroneously flagged with `ObfuscatedPhp` and `DodgyPhp`, so we're adding these particular files to the whitelist.

## Test instructions

1. Have `yara` installed (`brew install yara` if on macOS)
2. Download and unzip the vendor's plugin file (I can provide this)
3. In the `php-malware-finder` subdirectory, run the malware scanner against the unzipped folder: `yara -r ./php.yar /path/to/folder/you/downloaded`.
4. You should see a warning about `ObfuscatedPhp` and `DodgyPhp`. Note that `warning: rule "DodgyPhp" in ./php.yar(93): $pr contains .*, .+ or .{x,} consider using .{,N}, .{1,N} or {x,N} with a reasonable value for N` is expected and can be ignored.
5. Check out this branch and run the same command.
6. You should only see the message `warning: rule "DodgyPhp" in ./php.yar(93): $pr contains .*, .+ or .{x,} consider using .{,N}, .{1,N} or {x,N} with a reasonable value for N` and not any `DodgyStrings` or `ObfuscatedPhp` errors.